### PR TITLE
Fix waitFor success step bug

### DIFF
--- a/do_while.js
+++ b/do_while.js
@@ -85,8 +85,8 @@ casper.then = function then(step) {
         step.executed = false;                 // Added:  New Property. This navigation step is executed already or not.
         this.emit('step.added', step);         // Moved:  from bottom
     } else {
-
-      if( !this.steps[this.current].executed ) {  // Added:  Add step to this.steps only in the case of not being executed yet.
+      var isWaitSuccessFun = step.name.indexOf('successThen') != -1; // check if it's then step of waitFor
+      if( isWaitSuccessFun || !this.steps[this.current].executed ) {  // Added:  Add step to this.steps only in the case of not being executed yet.
         // insert substep a level deeper
         try {
 //          step.level = this.steps[this.step - 1].level + 1;   <=== Original
@@ -101,7 +101,9 @@ casper.then = function then(step) {
         this.steps.splice(insertIndex, 0, step);
         step.executed = false;                    // Added:  New Property. This navigation step is executed already or not.
         this.emit('step.added', step);            // Moved:  from bottom
-      }                                           // Added:  End of if() that is added.
+      } else {                                          // Added:  End of if() that is added.
+        //self.log('Step ' + step.name + ' was not executed because of do_while modification');
+      }
 
     }
 //    this.emit('step.added', step);   // Move above. Because then() is not always adding step. only first execution time.


### PR DESCRIPTION
Just include `successThen` into the name of waitFor success function to make it work like a charm.
Example:
```
casper.waitFor(
    function check(){
        // check if page is ready
    },
    function successThen(){
        // execute after page is ready
    },
    function(){
        // time out happened before page got ready
    },
    timeOutTime
);
```
Works for `waitForSelector` and other similar as well.
